### PR TITLE
fix: check if the file exists when added

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ cargo install --path .
 
 ```bash
 # Set default KeePass database
-keepass-2-file config set-default-kpdb /path/to/your.kdbx
+keepass-2-file config set-default-kp-db /path/to/your.kdbx
 
 # Get current KeePass database configuration
-keepass-2-file config get-kpdb
+keepass-2-file config get-kp-db
 
 # Generate environment file from template
 keepass-2-file build template.env.hbs .env

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -128,9 +128,14 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
     match args.command {
         Commands::Config(config_command) => match config_command {
             ConfigCommands::SetDefaultKpDb { url } => {
-                io.log(format!("Setting default KeePass DB URL: {:?}", url));
-                config.config.keepass = Some(url);
-                config.save()?;
+                let path = Path::new(&url);
+                if path.exists() {
+                    io.log(format!("Setting default KeePass DB URL: {:?}", url));
+                    config.config.keepass = Some(url);
+                    config.save()?;
+                } else {
+                    io.log(format!("The following file doesn't exist or it can't be accessed: {:?}", url));
+                }
             }
             ConfigCommands::GetKpDb => match config.config.keepass {
                 Some(url) => io.log(format!("Current file is {}", url)),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -129,13 +129,16 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
         Commands::Config(config_command) => match config_command {
             ConfigCommands::SetDefaultKpDb { url } => {
                 let path = Path::new(&url);
-                if path.is_absolute(){
+                if path.is_absolute() {
                     if path.exists() {
                         io.log(format!("Setting default KeePass DB URL: {:?}", url));
                         config.config.keepass = Some(url);
                         config.save()?;
                     } else {
-                        io.error(format!("The following file doesn't exist or it can't be accessed: {:?}", url));
+                        io.error(format!(
+                            "The following file doesn't exist or it can't be accessed: {:?}",
+                            url
+                        ));
                     }
                 } else {
                     io.error("The file path is not absolute. It must follow this format: /Users/username/**/*.kdbx".to_string());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -394,7 +394,7 @@ mod tests {
     fn test_set_default_keepass_file() {
         let test = TestConfig::create();
         let io = IODebug::new();
-        let relative_path = Path::new("test_resources\\test_db.kdbx");
+        let relative_path = Path::new("test_resources/test_db.kdbx");
         let absolute_path = fs::canonicalize(relative_path).unwrap();
         let absolute_path_string = absolute_path.to_str().unwrap();
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -129,12 +129,16 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
         Commands::Config(config_command) => match config_command {
             ConfigCommands::SetDefaultKpDb { url } => {
                 let path = Path::new(&url);
-                if path.exists() {
-                    io.log(format!("Setting default KeePass DB URL: {:?}", url));
-                    config.config.keepass = Some(url);
-                    config.save()?;
+                if path.is_absolute(){
+                    if path.exists() {
+                        io.log(format!("Setting default KeePass DB URL: {:?}", url));
+                        config.config.keepass = Some(url);
+                        config.save()?;
+                    } else {
+                        io.error(format!("The following file doesn't exist or it can't be accessed: {:?}", url));
+                    }
                 } else {
-                    io.log(format!("The following file doesn't exist or it can't be accessed: {:?}", url));
+                    io.error("The file path is not absolute. It must follow this format: /Users/username/**/*.kdbx".to_string());
                 }
             }
             ConfigCommands::GetKpDb => match config.config.keepass {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Added validation to ensure the default KeePass database path exists and is accessible before saving it to the configuration. Users will now receive a message if the provided path is invalid or inaccessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->