### PR TITLE
Added the logic to work with a local project config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -750,6 +750,7 @@ dependencies = [
  "dirs",
  "handlebars",
  "keepass",
+ "pathdiff",
  "rpassword",
  "serde",
  "serde_json",
@@ -835,6 +836,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ serde_yaml = "0.9.34"
 rpassword = "7.3.1"
 dirs = "6.0.0"
 colored = "3.0.0"
+pathdiff = "0.2.3"
 
 [dev-dependencies]
 test_helpers = { workspace = true}
+
+[features]
+keep-test-files = []

--- a/crates/test_helpers/src/tmp_file.rs
+++ b/crates/test_helpers/src/tmp_file.rs
@@ -11,12 +11,21 @@ impl TmpFile {
         }
     }
 
-    pub fn new_uuid(path: String, ext: String) -> Self {
+    pub fn new_uuid(path: impl Into<String>, ext: Option<impl Into<String>>) -> Self {
         let uuid = uuid::Uuid::new_v4();
-        let config_file = format!("{path}/{uuid}.{ext}");
+        let path = path.into();
+
+        let file_path = match ext {
+            Some(ext) => {
+                let ext = ext.into();
+
+                format!("{path}/{uuid}.{ext}")
+            }
+            None => format!("{path}/{uuid}"),
+        };
         let error = format!("Unable to create temporary {} directory", &path);
         std::fs::create_dir_all(path).expect(error.as_str());
-        Self::new(config_file)
+        Self::new(file_path)
     }
 
     pub fn write(&self, contents: String) {

--- a/justfile
+++ b/justfile
@@ -1,0 +1,6 @@
+test:
+    cargo test
+coverage:
+    cargo llvm-cov
+coverage-html:
+    cargo llvm-cov --open

--- a/justfile
+++ b/justfile
@@ -4,3 +4,5 @@ coverage:
     cargo llvm-cov
 coverage-html:
     cargo llvm-cov --open
+clippy:
+    cargo clippy -- -D warnings

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -104,7 +104,7 @@ pub enum ConfigCommands {
         #[arg(
             short,
             long,
-            help = "add the file in the current project configuration"
+            help = "delete the file in the current project configuration"
         )]
         local: bool,
     },

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -101,6 +101,12 @@ pub enum ConfigCommands {
     Delete {
         #[command(subcommand)]
         template: NameOrPath,
+        #[arg(
+            short,
+            long,
+            help = "add the file in the current project configuration"
+        )]
+        local: bool,
     },
 
     /// List default variables in the config

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -86,6 +86,12 @@ pub enum ConfigCommands {
             help = "when output is a relative path, it will make it relative to the folder of template when enabled or relative to current when disabled"
         )]
         relative_to_input: bool,
+        #[arg(
+            short,
+            long,
+            help = "add the file in the current project configuration"
+        )]
+        local: bool,
     },
 
     /// Deletes all templates that the source doesn't exists

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -121,8 +121,7 @@ impl ConfigHandler {
         let local_config = self
             .local
             .as_ref()
-            .map(|config| config.keepass.clone())
-            .flatten();
+            .and_then(|config| config.keepass.clone());
 
         match local_config {
             Some(keepass) => Some(keepass),
@@ -138,15 +137,24 @@ impl ConfigHandler {
         output: String,
     ) -> Result<(), ConfigError> {
         match destination {
-            SourceConfig::Global => Ok(self.global.add_template(name, template, output)),
+            SourceConfig::Global => {
+                self.global.add_template(name, template, output);
+                Ok(())
+            }
             SourceConfig::Project => {
                 let project = self.project.clone();
-                let mut local = self.local.clone().unwrap_or(YamlConfig::default());
+                let mut local = self.local.clone().unwrap_or_default();
                 let Some(relative_template) = pathdiff::diff_paths(&template, &project) else {
-                    return Err(ConfigError::new("Cannot convert template ({}) to relative").into());
+                    return Err(ConfigError::new(format!(
+                        "Cannot convert template ({}) to relative",
+                        template
+                    )));
                 };
-                let Some(relative_output) = pathdiff::diff_paths(output, &project) else {
-                    return Err(ConfigError::new("Cannot convert output ({}) to relative").into());
+                let Some(relative_output) = pathdiff::diff_paths(&output, &project) else {
+                    return Err(ConfigError::new(format!(
+                        "Cannot convert output ({}) to relative",
+                        output
+                    )));
                 };
                 local.add_template(
                     name,
@@ -154,7 +162,7 @@ impl ConfigHandler {
                         .into_os_string()
                         .into_string()
                         .map_err(|err| {
-                            ConfigError::new(&format!(
+                            ConfigError::new(format!(
                                 "Template path contains invalid UTF-8: {:?}",
                                 err
                             ))
@@ -163,7 +171,7 @@ impl ConfigHandler {
                         .into_os_string()
                         .into_string()
                         .map_err(|err| {
-                            ConfigError::new(&format!(
+                            ConfigError::new(format!(
                                 "Output path contains invalid UTF-8: {:?}",
                                 err
                             ))
@@ -185,6 +193,19 @@ impl ConfigHandler {
             SourceConfig::Global => {
                 self.global
                     .delete_template(&template.template, &template.output);
+            }
+        }
+    }
+
+    pub fn delete_templates(&mut self, source: SourceConfig, name: &String) {
+        match source {
+            SourceConfig::Project => {
+                if let Some(ref mut local) = self.local {
+                    local.delete_templates(name);
+                }
+            }
+            SourceConfig::Global => {
+                self.global.delete_templates(name);
             }
         }
     }

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -1,0 +1,277 @@
+pub mod yaml;
+
+use std::{fmt::Display, path::PathBuf};
+
+use yaml::YamlConfig;
+
+#[derive(Debug)]
+pub struct ConfigError {
+    msg: String,
+}
+impl std::error::Error for ConfigError {}
+impl Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl ConfigError {
+    fn new(msg: impl Into<String>) -> Self {
+        ConfigError { msg: msg.into() }
+    }
+}
+
+pub struct ConfigHandler {
+    file: String,
+    project: String,
+    pub global: YamlConfig,
+    pub local: Option<YamlConfig>,
+}
+
+pub const PROJECT_FILE: &str = ".keepass-2-file";
+
+impl ConfigHandler {
+    fn get_project_file(project: &String) -> Option<PathBuf> {
+        let mut project_path = std::path::Path::new(project).to_path_buf();
+        if project_path.is_dir() {
+            project_path.push(PROJECT_FILE);
+            return Some(project_path);
+        }
+        None
+    }
+
+    pub fn new(file: &str, project: String) -> Result<ConfigHandler, Box<dyn std::error::Error>> {
+        if !std::path::Path::new(file).exists() {
+            std::fs::write(file, "")?;
+        }
+
+        let contents = std::fs::read_to_string(file)?;
+
+        let config = YamlConfig::new(&contents)?;
+
+        let local_config_file = Self::get_project_file(&project);
+
+        let local: Option<YamlConfig> = match local_config_file {
+            Some(config_path) => {
+                if config_path.exists() && config_path.is_file() {
+                    let config = config_path.into_os_string().into_string().map_err(|err| {
+                        ConfigError::new(format!("Path containing invalid UTF-8 code: {:?}", err))
+                    })?;
+                    let contents = std::fs::read_to_string(config)?;
+                    Some(YamlConfig::new(&contents)?)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+
+        Ok(ConfigHandler {
+            file: file.to_string(),
+            global: config,
+            local,
+            project,
+        })
+    }
+
+    pub fn get_file(&self) -> &str {
+        &self.file
+    }
+
+    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let global_content = self.global.yaml()?;
+        std::fs::write(&self.file, global_content)?;
+        if let Some(local) = &self.local {
+            let local_content = local.yaml()?;
+            let Some(local_file) = Self::get_project_file(&self.project) else {
+                return Err(ConfigError::new( "Cannot get the local project file, any changes in the project config won't be saved").into());
+            };
+            std::fs::write(local_file, local_content)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum SourceConfig {
+    Project,
+    Global,
+}
+
+impl std::fmt::Display for SourceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let text = match self {
+            Self::Project => "PROJECT",
+            Self::Global => "GLOBAL",
+        };
+        f.write_str(text)
+    }
+}
+
+#[derive(Debug)]
+pub struct TemplateInfo {
+    pub source: SourceConfig,
+    pub name: Option<String>,
+    pub template: String,
+    pub output: String,
+}
+
+impl ConfigHandler {
+    pub fn keepass(&self) -> Option<String> {
+        let local_config = self
+            .local
+            .as_ref()
+            .map(|config| config.keepass.clone())
+            .flatten();
+
+        match local_config {
+            Some(keepass) => Some(keepass),
+            None => self.global.keepass.clone(),
+        }
+    }
+
+    pub fn add_template(
+        &mut self,
+        destination: SourceConfig,
+        name: Option<String>,
+        template: String,
+        output: String,
+    ) -> Result<(), ConfigError> {
+        match destination {
+            SourceConfig::Global => Ok(self.global.add_template(name, template, output)),
+            SourceConfig::Project => {
+                let project = self.project.clone();
+                let mut local = self.local.clone().unwrap_or(YamlConfig::default());
+                let Some(relative_template) = pathdiff::diff_paths(&template, &project) else {
+                    return Err(ConfigError::new("Cannot convert template ({}) to relative").into());
+                };
+                let Some(relative_output) = pathdiff::diff_paths(output, &project) else {
+                    return Err(ConfigError::new("Cannot convert output ({}) to relative").into());
+                };
+                local.add_template(
+                    name,
+                    relative_template
+                        .into_os_string()
+                        .into_string()
+                        .map_err(|err| {
+                            ConfigError::new(&format!(
+                                "Template path contains invalid UTF-8: {:?}",
+                                err
+                            ))
+                        })?,
+                    relative_output
+                        .into_os_string()
+                        .into_string()
+                        .map_err(|err| {
+                            ConfigError::new(&format!(
+                                "Output path contains invalid UTF-8: {:?}",
+                                err
+                            ))
+                        })?,
+                );
+                self.local = Some(local);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn delete_template(&mut self, template: &TemplateInfo) {
+        match template.source {
+            SourceConfig::Project => {
+                if let Some(ref mut local) = self.local {
+                    local.delete_template(&template.template, &template.output);
+                }
+            }
+            SourceConfig::Global => {
+                self.global
+                    .delete_template(&template.template, &template.output);
+            }
+        }
+    }
+
+    pub fn get_templates(&self) -> Vec<TemplateInfo> {
+        let mut templates: Vec<TemplateInfo> = self
+            .global
+            .get_templates()
+            .iter()
+            .map(|template| TemplateInfo {
+                source: SourceConfig::Global,
+                name: template.name.clone(),
+                template: template.template_path.clone(),
+                output: template.output_path.clone(),
+            })
+            .collect();
+        if let Some(ref local) = self.local {
+            templates.extend(local.get_templates().iter().map(|template| TemplateInfo {
+                source: SourceConfig::Project,
+                name: template.name.clone(),
+                template: format!("{}/{}", self.project, template.template_path.clone()),
+                output: format!("{}/{}", self.project, template.output_path.clone()),
+            }));
+        }
+
+        templates
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::app::{config::PROJECT_FILE, test_helpers::tests::TestConfig};
+
+    #[test]
+    fn test_loading_empty_file() {
+        let test_config = TestConfig::create_empty_file();
+        std::fs::write(test_config.get_file_path(), "{}").expect("Can write test file");
+
+        let config = test_config.get();
+
+        assert_eq!(config.global.get_templates().len(), 0);
+    }
+
+    #[test]
+    fn test_keepass_from_project() {
+        let test_config = TestConfig::create();
+        std::fs::write(
+            format!("{}/{}", test_config.get_project_path(), PROJECT_FILE),
+            "version: 2\nkeepass: /some/stupid/url.keepass",
+        )
+        .expect("We have a default for the project");
+
+        let config = test_config.get();
+
+        assert_eq!(config.keepass().unwrap(), "/some/stupid/url.keepass")
+    }
+
+    #[test]
+    fn test_keepass_from_global() {
+        let test_config = TestConfig::create();
+        std::fs::write(
+            format!("{}/{}", test_config.get_project_path(), PROJECT_FILE),
+            "version: 2\n",
+        )
+        .expect("We have a default for the project");
+
+        let config = test_config.get();
+
+        assert!(
+            config
+                .keepass()
+                .unwrap()
+                .ends_with("test_resources/test_db.kdbx")
+        )
+    }
+
+    #[test]
+    fn test_keepass_from_global_without_project() {
+        let test_config = TestConfig::create();
+
+        let config = test_config.get();
+
+        assert!(
+            config
+                .keepass()
+                .unwrap()
+                .ends_with("test_resources/test_db.kdbx")
+        )
+    }
+}

--- a/src/app/config/yaml.rs
+++ b/src/app/config/yaml.rs
@@ -10,7 +10,7 @@ pub struct YamlConfigTemplate {
     pub output_path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct YamlConfig {
     pub keepass: Option<String>,
 
@@ -40,6 +40,23 @@ enum YamlConfigVersioned {
 }
 
 impl YamlConfig {
+    pub fn new(contents: &str) -> Result<Self, serde_yaml::Error> {
+        if contents.is_empty() {
+            Ok(YamlConfig::default())
+        } else {
+            let versioned: YamlConfigVersioned = serde_yaml::from_str(&contents)?;
+            match versioned {
+                YamlConfigVersioned::Latest(conf) => Ok(conf),
+                YamlConfigVersioned::Legacy(legacy) => Ok(legacy.into()),
+            }
+        }
+    }
+
+    pub fn yaml(&self) -> Result<String, serde_yaml::Error> {
+        let version = YamlConfigVersioned::Latest(self.clone());
+        serde_yaml::to_string(&version)
+    }
+
     pub fn get_templates(&self) -> Vec<YamlConfigTemplate> {
         self.templates.to_vec()
     }
@@ -83,11 +100,11 @@ impl YamlConfig {
             .collect();
     }
 
-    pub fn delete_template(&mut self, template_path: String, output_path: String) {
+    pub fn delete_template(&mut self, template_path: &String, output_path: &String) {
         let templates = self.templates.clone().into_iter();
         self.templates = templates
             .filter(|template| {
-                !(template.template_path == template_path && template.output_path == output_path)
+                !(template.template_path == *template_path && template.output_path == *output_path)
             })
             .collect();
     }
@@ -116,64 +133,5 @@ impl From<YamlConfigV1> for YamlConfig {
             templates: value.templates.unwrap_or_default(),
             variables: value.variables.unwrap_or_default(),
         }
-    }
-}
-
-pub struct ConfigHandler {
-    file: String,
-    pub config: YamlConfig,
-}
-
-impl ConfigHandler {
-    pub fn new(file: &str) -> Result<ConfigHandler, Box<dyn std::error::Error>> {
-        if !std::path::Path::new(file).exists() {
-            std::fs::write(file, "")?;
-        }
-
-        let contents = std::fs::read_to_string(file)?;
-        let config = if contents.is_empty() {
-            YamlConfig {
-                keepass: None,
-                templates: Vec::new(),
-                variables: HashMap::new(),
-            }
-        } else {
-            let versioned: YamlConfigVersioned = serde_yaml::from_str(&contents)?;
-            match versioned {
-                YamlConfigVersioned::Latest(conf) => conf,
-                YamlConfigVersioned::Legacy(legacy) => legacy.into(),
-            }
-        };
-
-        Ok(ConfigHandler {
-            file: file.to_string(),
-            config,
-        })
-    }
-
-    pub fn get_file(&self) -> &str {
-        &self.file
-    }
-
-    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let version = YamlConfigVersioned::Latest(self.config.clone());
-        let yaml = serde_yaml::to_string(&version)?;
-        std::fs::write(&self.file, yaml)?;
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::app::test_helpers::tests::TestConfig;
-
-    #[test]
-    fn test_loading_empty_file() {
-        let test_config = TestConfig::create_empty_file();
-        std::fs::write(test_config.get_file_path(), "{}").expect("Can write test file");
-
-        let config = test_config.get();
-
-        assert_eq!(config.config.get_templates().len(), 0);
     }
 }

--- a/src/app/config/yaml.rs
+++ b/src/app/config/yaml.rs
@@ -41,10 +41,10 @@ enum YamlConfigVersioned {
 
 impl YamlConfig {
     pub fn new(contents: &str) -> Result<Self, serde_yaml::Error> {
-        if contents.is_empty() {
+        if contents.trim().is_empty() {
             Ok(YamlConfig::default())
         } else {
-            let versioned: YamlConfigVersioned = serde_yaml::from_str(&contents)?;
+            let versioned: YamlConfigVersioned = serde_yaml::from_str(contents)?;
             match versioned {
                 YamlConfigVersioned::Latest(conf) => Ok(conf),
                 YamlConfigVersioned::Legacy(legacy) => Ok(legacy.into()),
@@ -88,12 +88,12 @@ impl YamlConfig {
         self.templates = templates
     }
 
-    pub fn delete_templates(&mut self, name: String) {
+    pub fn delete_templates(&mut self, name: &String) {
         let templates = self.templates.clone().into_iter();
         self.templates = templates
             .filter(|template| {
                 if let Some(template_name) = &template.name {
-                    return &name != template_name;
+                    return name != template_name;
                 }
                 true
             })

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,7 +10,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::app::{config::SourceConfig, logs_prefix::LOG_PREFIX};
+use crate::app::{
+    config::{SourceConfig, TemplateInfo},
+    logs_prefix::LOG_PREFIX,
+};
 
 pub mod commands;
 pub mod config;
@@ -215,7 +218,7 @@ pub fn execute(project: String, args: Cli, io: &dyn IOLogs) -> Result<(), Box<dy
                     io.error("The file path is not absolute. It must follow this format: /Users/username/**/*.kdbx on Mac, or C:\\**\\*.kdbx on Windows".to_string());
                 }
             }
-            ConfigCommands::GetKpDb => match config.global.keepass {
+            ConfigCommands::GetKpDb => match config.keepass() {
                 Some(url) => io.log(format!("Current file is {url}")),
                 None => io.log(format!(
                     "The current configuration '{}' doesn't contain a default keepass db",
@@ -268,13 +271,23 @@ pub fn execute(project: String, args: Cli, io: &dyn IOLogs) -> Result<(), Box<dy
                 }
                 config.save()?;
             }
-            ConfigCommands::Delete { template } => {
+            ConfigCommands::Delete { template, local } => {
+                let source = if local {
+                    SourceConfig::Project
+                } else {
+                    SourceConfig::Global
+                };
                 match template {
                     NameOrPath::Name { name } => {
-                        config.global.delete_templates(name);
+                        config.delete_templates(source, &name);
                     }
                     NameOrPath::Paths { path, output } => {
-                        config.global.delete_template(&path, &output);
+                        config.delete_template(&TemplateInfo {
+                            source,
+                            name: None,
+                            template: path,
+                            output,
+                        });
                     }
                 }
                 config.save()?;
@@ -627,6 +640,37 @@ mod tests {
     }
 
     #[test]
+    fn test_adding_new_abs_path_global_template() {
+        let test = TestConfig::create();
+        let io = IODebug::new();
+        let result = execute(
+            test.get_project_path(),
+            Cli {
+                disable_warnings: false,
+                command: Commands::Config(ConfigCommands::AddFile {
+                    name: Some(String::from("New template")),
+                    template: String::from("./test_resources/file-with-error"),
+                    output: String::from("/tmp/error"),
+                    relative_to_input: true,
+                    local: false,
+                }),
+                config: Some(String::from(test.get_file_path())),
+            },
+            &io,
+        );
+
+        println!("{:?}", result);
+        assert!(result.is_ok());
+
+        let out_config = test.get();
+
+        let templates = out_config.global.get_templates();
+        assert_eq!(templates.len(), 4);
+        assert_eq!(templates[3].name, Some(String::from("New template")));
+        assert_eq!(templates[3].output_path, String::from("/tmp/error"));
+    }
+
+    #[test]
     fn test_adding_new_local_template() {
         let test = TestConfig::create();
         let io = IODebug::new();
@@ -919,6 +963,7 @@ mod tests {
                     template: NameOrPath::Name {
                         name: String::from("other"),
                     },
+                    local: false,
                 }),
             },
             &io,
@@ -931,6 +976,42 @@ mod tests {
         let templates = out_config.global.get_templates();
         assert_eq!(templates.len(), 2);
         assert_eq!(templates[1].name, Some(String::from("valid")));
+    }
+
+    #[test]
+    fn test_delete_local_template() {
+        let test = TestConfig::create();
+        test.set_project_contents(
+            "templates:
+            - template_path: ./test_resources/file-with-error
+              output_path: ./tmp/error",
+        );
+        let io = IODebug::new();
+        let result = execute(
+            test.get_project_path(),
+            Cli {
+                disable_warnings: false,
+                command: Commands::Config(ConfigCommands::Delete {
+                    template: NameOrPath::Paths {
+                        path: String::from("./test_resources/file-with-error"),
+                        output: String::from("./tmp/error"),
+                    },
+                    local: true,
+                }),
+                config: Some(String::from(test.get_file_path())),
+            },
+            &io,
+        );
+
+        println!("{:?}", result);
+        assert!(result.is_ok());
+
+        let out_config = test.get();
+
+        assert_eq!(out_config.global.get_templates().len(), 3);
+
+        let templates = out_config.local.unwrap().get_templates();
+        assert_eq!(templates.len(), 0);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::app::logs_prefix::LOG_PREFIX;
+use crate::app::{config::SourceConfig, logs_prefix::LOG_PREFIX};
 
 pub mod commands;
 pub mod config;
@@ -182,7 +182,7 @@ fn parse_variables(io: &dyn IOLogs, variables: Vec<String>) -> HashMap<String, S
     parsed_variables
 }
 
-pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
+pub fn execute(project: String, args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
     let home = dirs::home_dir()
         .ok_or("Could not determine home directory")?
         .to_str()
@@ -193,7 +193,7 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|| format!("{home}/.config/keepass-2-file.yaml"));
 
     // Load and parse the configuration file
-    let mut config = ConfigHandler::new(&config_path)?;
+    let mut config = ConfigHandler::new(&config_path, get_absolute_path(project))?;
 
     let warnings_enabled = !args.disable_warnings;
 
@@ -204,7 +204,7 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
                 if path.is_absolute() {
                     if path.exists() {
                         io.log(format!("Setting default KeePass DB URL: {url:?}"));
-                        config.config.keepass = Some(url);
+                        config.global.keepass = Some(url);
                         config.save()?;
                     } else {
                         io.error(format!(
@@ -215,7 +215,7 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
                     io.error("The file path is not absolute. It must follow this format: /Users/username/**/*.kdbx on Mac, or C:\\**\\*.kdbx on Windows".to_string());
                 }
             }
-            ConfigCommands::GetKpDb => match config.config.keepass {
+            ConfigCommands::GetKpDb => match config.global.keepass {
                 Some(url) => io.log(format!("Current file is {url}")),
                 None => io.log(format!(
                     "The current configuration '{}' doesn't contain a default keepass db",
@@ -223,16 +223,13 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
                 )),
             },
             ConfigCommands::ListFiles => {
-                let templates = config.config.get_templates();
+                let templates = config.get_templates();
                 if templates.is_empty() {
                     io.log(String::from("No templates defined"));
                 } else {
                     io.log(String::from("Configured templates:"));
                     for template in templates {
-                        io.log(format!(
-                            "\t {} -> {}",
-                            template.template_path, template.output_path
-                        ));
+                        io.log(format!("\t {} -> {}", template.template, template.output));
                     }
                 }
             }
@@ -241,27 +238,32 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
                 template,
                 output,
                 relative_to_input,
+                local,
             } => {
                 let output_path = get_output_path(&template, output, relative_to_input);
-                config.config.add_template(
+                let source = if local {
+                    SourceConfig::Project
+                } else {
+                    SourceConfig::Global
+                };
+                config.add_template(
+                    source,
                     name,
                     get_absolute_path(template),
                     get_absolute_path(output_path),
-                );
+                )?;
                 config.save()?;
             }
             ConfigCommands::Prune => {
-                let templates = config.config.get_templates();
+                let templates = config.get_templates();
                 for template in templates {
                     io.log(format!("{template:?}"));
-                    if !Path::new(&template.template_path).exists() {
+                    if !Path::new(&template.template).exists() {
                         io.log(format!(
-                            "Template {} does not exist, removing from config",
-                            template.template_path
+                            "Template {}:{} does not exist, removing from config",
+                            template.source, template.template
                         ));
-                        config
-                            .config
-                            .delete_template(template.template_path, template.output_path);
+                        config.delete_template(&template);
                     }
                 }
                 config.save()?;
@@ -269,16 +271,16 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
             ConfigCommands::Delete { template } => {
                 match template {
                     NameOrPath::Name { name } => {
-                        config.config.delete_templates(name);
+                        config.global.delete_templates(name);
                     }
                     NameOrPath::Paths { path, output } => {
-                        config.config.delete_template(path, output);
+                        config.global.delete_template(&path, &output);
                     }
                 }
                 config.save()?;
             }
             ConfigCommands::ListVariables => {
-                let variables = config.config.get_vars();
+                let variables = config.global.get_vars();
                 if variables.is_empty() {
                     io.log(String::from("No variables defined"));
                 } else {
@@ -299,13 +301,13 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
             ConfigCommands::AddVariables { variables } => {
                 let vars_hash = parse_variables(io, variables);
                 for (key, value) in vars_hash {
-                    config.config.add_var(key, value);
+                    config.global.add_var(key, value);
                 }
                 config.save()?;
             }
             ConfigCommands::DeleteVariables { variables } => {
                 for variable in variables {
-                    config.config.del_var(variable.to_string());
+                    config.global.del_var(variable.to_string());
                 }
                 config.save()?;
             }
@@ -319,20 +321,18 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
         } => {
             io.log(format!("Building template file: {template}"));
             io.log(format!("KeePass file: {keepass:?}"));
-            let mut variables = config.config.get_vars();
+            let mut variables = config.global.get_vars();
             variables.extend(parse_variables(io, vars));
 
             let keepass = match keepass {
                 Some(url) => url,
-                None => {
-                    match config.config.keepass {
-                        Some(url) => url,
-                        None => {
-                            io.log(String::from("No keepass file configured in global config or passed as parameter"));
-                            return Err("No keepass file configured in global config or passed as parameter".into());
-                        }
+                None => match config.keepass() {
+                    Some(url) => url,
+                    None => {
+                        io.log(String::from("No keepass file configured in global config, project config or passed as parameter"));
+                        return Err("No keepass file configured in global config, project config or passed as parameter".into());
                     }
-                }
+                },
             };
 
             let db = open_keepass_db(keepass, io)?;
@@ -359,16 +359,18 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
             }
         }
         Commands::BuildAll { vars } => {
-            let mut variables = config.config.get_vars();
+            let mut variables = config.global.get_vars();
             variables.extend(parse_variables(io, vars));
 
-            let files = config.config.get_templates();
-            let keepass = match config.config.keepass {
+            let files = config.get_templates();
+            let keepass = match config.keepass() {
                 Some(url) => url,
                 None => {
-                    io.log(String::from("No keepass file configured in global config"));
+                    io.log(String::from(
+                        "No keepass file configured in global config or project config",
+                    ));
                     return Err(
-                        "No keepass file configured in global config or passed as parameter".into(),
+                        "No keepass file configured in global config or project config".into(),
                     );
                 }
             };
@@ -388,21 +390,21 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
             for template in files {
                 let name = match template.name {
                     Some(ref name) => name.clone(),
-                    None => template.template_path.clone(),
+                    None => template.template.clone(),
                 };
                 let result = render_and_save_template(
                     &mut handlebars,
                     io,
                     name.clone(),
-                    template.template_path.clone(),
-                    template.output_path.clone(),
+                    template.template.clone(),
+                    template.output.clone(),
                     &variables,
                 );
                 if let Err(err) = result {
                     let name = match template.name {
                         Some(name) => name,
                         None => {
-                            format!("{} => {}", template.template_path, template.output_path)
+                            format!("{} => {}", template.template, template.output)
                         }
                     };
                     io.log(format!("Skipping template {name} because of: {err:?}"));
@@ -411,7 +413,7 @@ pub fn execute(args: Cli, io: &dyn IOLogs) -> Result<(), Box<dyn Error>> {
                 if !errors.is_empty() {
                     io.error(format!(
                         "There were some errors processing {}:",
-                        template.template_path
+                        template.template
                     ));
                     for error in errors {
                         error.to_io_logs(io, warnings_enabled);
@@ -462,6 +464,7 @@ mod tests {
 
         // Test get keepass with empty config
         let get_result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::GetKpDb),
@@ -473,6 +476,7 @@ mod tests {
 
         // Test list templates with empty config
         let list_templates_result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::ListFiles),
@@ -484,6 +488,7 @@ mod tests {
 
         // Test list variables with empty config
         let list_vars_result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::ListVariables),
@@ -512,6 +517,7 @@ mod tests {
         let absolute_path_string = absolute_path.to_str().unwrap();
 
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::SetDefaultKpDb {
@@ -526,7 +532,7 @@ mod tests {
 
         let config = test.get();
         assert_eq!(
-            config.config.keepass,
+            config.global.keepass,
             Some(String::from(absolute_path_string))
         );
 
@@ -544,6 +550,7 @@ mod tests {
 
         // Then get it
         let get_result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::GetKpDb),
@@ -561,9 +568,15 @@ mod tests {
     #[test]
     fn test_list_files() {
         let test = TestConfig::create();
+        test.set_project_contents(
+            "templates:
+  - template_path: ./tmp/test_local
+    output_path: ./tmp/test_output",
+        );
         let io = IODebug::new();
 
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::ListFiles),
@@ -576,16 +589,19 @@ mod tests {
 
         let logs = io.get_logs();
         println!("{:?}", logs);
-        assert_eq!(logs.len(), 4);
+        assert_eq!(logs.len(), 5);
         assert_eq!(logs[0], "Configured templates:");
         assert!(logs[2].contains(&normalize_separators("/test_resources/.env.example -> ")));
+        assert!(logs[4].contains(&test.get_project_path()));
+        assert!(logs[4].contains("tmp/test_local"));
     }
 
     #[test]
-    fn test_adding_new_template() {
+    fn test_adding_new_global_template() {
         let test = TestConfig::create();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::AddFile {
@@ -593,6 +609,7 @@ mod tests {
                     template: String::from("./test_resources/file-with-error"),
                     output: String::from("./tmp/error"),
                     relative_to_input: true,
+                    local: false,
                 }),
                 config: Some(String::from(test.get_file_path())),
             },
@@ -604,9 +621,44 @@ mod tests {
 
         let out_config = test.get();
 
-        let templates = out_config.config.get_templates();
+        let templates = out_config.global.get_templates();
         assert_eq!(templates.len(), 4);
         assert_eq!(templates[3].name, Some(String::from("New template")));
+    }
+
+    #[test]
+    fn test_adding_new_local_template() {
+        let test = TestConfig::create();
+        let io = IODebug::new();
+        let result = execute(
+            test.get_project_path(),
+            Cli {
+                disable_warnings: false,
+                command: Commands::Config(ConfigCommands::AddFile {
+                    name: Some(String::from("New template")),
+                    template: String::from("./test_resources/file-with-error"),
+                    output: String::from("./tmp/error"),
+                    relative_to_input: true,
+                    local: true,
+                }),
+                config: Some(String::from(test.get_file_path())),
+            },
+            &io,
+        );
+
+        println!("{:?}", result);
+        assert!(result.is_ok());
+
+        let out_config = test.get();
+
+        assert_eq!(out_config.global.get_templates().len(), 3);
+
+        let templates = out_config.local.unwrap().get_templates();
+        assert_eq!(templates.len(), 1);
+        let template = templates.first().unwrap();
+        assert_eq!(template.name, Some(String::from("New template")));
+        assert_eq!(template.template_path, "../../../file-with-error");
+        assert_eq!(template.output_path, "../../error");
     }
 
     #[test]
@@ -614,6 +666,7 @@ mod tests {
         let test = TestConfig::create_normalized();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Config(ConfigCommands::AddFile {
@@ -621,6 +674,7 @@ mod tests {
                     template: String::from("./test_resources/.env.example"),
                     output: String::from("./test_resources/tmp/.env"),
                     relative_to_input: false,
+                    local: false,
                 }),
                 config: Some(String::from(test.get_file_path())),
             },
@@ -632,16 +686,18 @@ mod tests {
 
         let out_config = test.get();
 
-        let templates = out_config.config.get_templates();
+        let templates = out_config.global.get_templates();
         assert_eq!(templates.len(), 2);
         assert_eq!(templates[0].name, Some(String::from("New name")));
     }
 
     #[test]
     fn test_rendering_invalid_handlebars_template() {
+        let test = TestConfig::create_empty_file();
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
         let ret = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 command: Commands::Build {
@@ -678,6 +734,7 @@ mod tests {
         let test = TestConfig::create_with_errors();
         io.add_stdin("MyTestPass".to_string());
         let result = execute(
+            test.get_project_path(),
             Cli::parse_from([
                 "kp2f",
                 "--config",
@@ -707,11 +764,13 @@ mod tests {
     #[test]
     fn test_render_all_errors() {
         let _colorized = OverrideColorize::new(false);
+        let test = TestConfig::create_empty_file();
 
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
 
         let result = execute(
+            test.get_project_path(),
             Cli::parse_from([
                 "kp2f",
                 "build",
@@ -767,11 +826,13 @@ mod tests {
     #[test]
     fn test_render_only_errors() {
         let _colorized = OverrideColorize::new(false);
+        let test = TestConfig::create_empty_file();
 
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
 
         let result = execute(
+            test.get_project_path(),
             Cli::parse_from([
                 "kp2f",
                 "--disable-warnings",
@@ -827,6 +888,7 @@ mod tests {
         let test = TestConfig::create();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -839,7 +901,7 @@ mod tests {
 
         let out_config = test.get();
 
-        let templates = out_config.config.get_templates();
+        let templates = out_config.global.get_templates();
         assert_eq!(templates.len(), 2);
         assert_eq!(templates[0].name, Some(String::from("valid")));
     }
@@ -849,6 +911,7 @@ mod tests {
         let test = TestConfig::create();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -865,7 +928,7 @@ mod tests {
 
         let out_config = test.get();
 
-        let templates = out_config.config.get_templates();
+        let templates = out_config.global.get_templates();
         assert_eq!(templates.len(), 2);
         assert_eq!(templates[1].name, Some(String::from("valid")));
     }
@@ -876,6 +939,7 @@ mod tests {
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -894,6 +958,7 @@ mod tests {
         let test = TestConfig::create();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -909,7 +974,7 @@ mod tests {
         println!("{:?}", result);
         assert!(result.is_ok());
 
-        let variables = test.get().config.get_vars();
+        let variables = test.get().global.get_vars();
         assert_eq!(variables.len(), 2);
         assert_eq!(variables.get("var1"), Some(&String::from("Some variable")));
         assert_eq!(variables.get("email"), Some(&String::from("j@k.com")));
@@ -921,6 +986,7 @@ mod tests {
         let io = IODebug::new();
 
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(test.get_file_path()),
@@ -944,6 +1010,7 @@ mod tests {
         let test = TestConfig::create_with_vars();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -956,11 +1023,11 @@ mod tests {
         println!("{:?}", result);
         assert!(result.is_ok());
 
-        let variables = test.get().config.get_vars();
+        let variables = test.get().global.get_vars();
         assert_eq!(variables.len(), 1);
         assert_eq!(variables.get("email"), Some(&String::from("j@k.com")));
 
-        let templates = test.get().config.get_templates();
+        let templates = test.get().global.get_templates();
         assert_eq!(templates.len(), 2);
         assert_eq!(templates[0].name, Some(String::from("valid")));
     }
@@ -970,6 +1037,7 @@ mod tests {
         let test = TestConfig::create();
         let io = IODebug::new();
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -988,7 +1056,7 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        let variables = test.get().config.get_vars();
+        let variables = test.get().global.get_vars();
 
         // Only 3 variables should be added (the one without '=' is skipped)
         assert_eq!(variables.len(), 2);
@@ -1012,6 +1080,7 @@ mod tests {
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),
@@ -1040,6 +1109,7 @@ mod tests {
         let mut io = IODebug::new();
         io.add_stdin("MyTestPass".to_string());
         let result = execute(
+            test.get_project_path(),
             Cli {
                 disable_warnings: false,
                 config: Some(String::from(test.get_file_path())),

--- a/src/app/test_helpers.rs
+++ b/src/app/test_helpers.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 pub mod tests {
+    use crate::app::config::PROJECT_FILE;
+
     use super::super::IOLogs;
     use super::super::commands::{Cli, Commands, ConfigCommands};
     use super::super::config::ConfigHandler;
@@ -9,6 +11,7 @@ pub mod tests {
 
     pub struct TestConfig {
         config: TmpFile,
+        project: TmpFile,
     }
 
     impl TestConfig {
@@ -16,17 +19,30 @@ pub mod tests {
             self.config.get()
         }
 
+        pub fn get_project_path(&self) -> String {
+            self.project.get()
+        }
+
         pub fn get(&self) -> ConfigHandler {
-            ConfigHandler::new(&self.config.get())
+            ConfigHandler::new(&self.config.get(), self.project.get())
                 .expect("Failed to load temp config created by TestConfig")
         }
 
         fn create_config(content: Option<String>) -> TestConfig {
-            let config = TmpFile::new_uuid("test_resources/tmp".into(), "yml".into());
+            let config = TmpFile::new_uuid("test_resources/tmp", Some("yml"));
             if let Some(content) = content {
                 config.write(content)
             }
-            TestConfig { config }
+            let project = TmpFile::new_uuid("test_resources/tmp/project", None::<String>);
+
+            std::fs::create_dir_all(project.get()).expect("Cannot create temporal project folder");
+
+            let test = TestConfig { config, project };
+
+            #[cfg(feature = "keep-test-files")]
+            let test = test.disable_auto_clean();
+
+            test
         }
 
         pub fn create() -> TestConfig {
@@ -65,6 +81,7 @@ templates:
             let test = TestConfig::create_config(Some(test_config));
             let io = IODebug::new();
             let result1 = execute(
+                test.get_project_path(),
                 Cli {
                     disable_warnings: false,
                     command: Commands::Config(ConfigCommands::AddFile {
@@ -72,6 +89,7 @@ templates:
                         template: String::from("./test_resources/.env.example"),
                         output: String::from("./test_resources/tmp/.env"),
                         relative_to_input: false,
+                        local: false,
                     }),
                     config: Some(String::from(test.get_file_path())),
                 },
@@ -81,6 +99,7 @@ templates:
             assert!(result1.is_ok());
 
             let result2 = execute(
+                test.get_project_path(),
                 Cli {
                     disable_warnings: false,
                     command: Commands::Config(ConfigCommands::AddFile {
@@ -88,6 +107,7 @@ templates:
                         template: String::from("./test_resources/.env.example"),
                         output: String::from("./test_resources/tmp/.env2"),
                         relative_to_input: false,
+                        local: false,
                     }),
                     config: Some(String::from(test.get_file_path())),
                 },
@@ -147,9 +167,15 @@ variables:
             TestConfig::create_config(None)
         }
 
-        #[allow(dead_code)]
-        pub fn disable_auto_clean(&mut self) -> &TestConfig {
+        pub fn set_project_contents(&self, contents: &str) {
+            std::fs::write(format!("{}/{}", self.project.get(), PROJECT_FILE), contents)
+                .expect("The projct config file can be writen");
+        }
+
+        #[cfg(feature = "keep-test-files")]
+        pub fn disable_auto_clean(mut self) -> TestConfig {
             self.config.disable_auto_clean();
+            self.project.disable_auto_clean();
             self
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         generate(shell, &mut cmd, name, &mut io::stdout());
         Ok(())
     } else {
-        execute(args, &Console {})
+        let project = std::env::current_dir()?.to_str().unwrap().to_string();
+        execute(project, args, &Console {})
     }
 }

--- a/tests/config-upgrade.rs
+++ b/tests/config-upgrade.rs
@@ -6,7 +6,7 @@ fn create_v1_config() -> TmpFile {
     let current_path = std::env::current_dir().unwrap();
     let current_path_string = current_path.to_str().unwrap();
 
-    let file = TmpFile::new_uuid("test_resources/tmp/".into(), "yml".into());
+    let file = TmpFile::new_uuid("test_resources/tmp/", Some("yml"));
     file.write(format!(
         "keepass: {current_path_string}/test_resources/db.kdbx
 templates: null"


### PR DESCRIPTION
fix #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --local flag to config add-file and delete commands for project-local config management
  * Config now supports layered global + project-local settings; local entries override global ones and can store project-relative template paths

* **Chores**
  * Added recipes for test, coverage, coverage-html, and clippy

* **Tests**
  * Updated test utilities and tests to exercise project-local config behavior and CLI flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->