### PR TITLE
Update dependencies, and bump kp2f version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "keepass"
-version = "0.12.5"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fc86fef36c8c2afa453a6d86e95caa7ea85c4385cdebb5e4eaf3caf89cf8f1"
+checksum = "4b943c051b52adc273806aaa44270f1ed77bbc8cd2a01f5aba8d73ef2ec6a68f"
 dependencies = [
  "aes",
  "base64",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "keepass-2-file"
-version = "0.6.2"
+version = "1.0.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "0.6.2"
+version = "1.0.0"
 dependencies = [
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ resolver="2"
 
 [workspace.package]
 author = "Jaume Singla"
-version = "0.6.2"
+version = "1.0.0"
 edition = "2024"
 
 [workspace.dependencies]
 test_helpers = {path="crates/test_helpers"}
-uuid = "1.16.0"
+uuid = "1.23.1"
 
 [dependencies]
-keepass = "0.12.5"
+keepass = "0.12.9"
 serde = { version = "1.0.0", features=["derive"] }
 serde_json = "1.0.39"
 handlebars="6.2.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Workspace version updated to 1.0.0
  * Rust edition upgraded to 2024
  * Dependencies updated: uuid to 1.23.1 and keepass to 0.12.9

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dracks/keepass-2-file/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->